### PR TITLE
fix: Cloudwatch event rule name from variables

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_log_group" "this" {
 }
 
 resource "aws_cloudwatch_event_rule" "this" {
-  name          = "codecommit-backups"
+  name          = var.name
   description   = "This rule is used to trigger CodeCommit backups to S3"
   event_pattern = <<EOF
 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I was using the variable `name` to split dev and prod envs, and found this resource had the name hardcoded, breaking my envs division.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
